### PR TITLE
Fix GPT-4o model version

### DIFF
--- a/aria_agents/chatbot_extensions/config.json
+++ b/aria_agents/chatbot_extensions/config.json
@@ -1,5 +1,5 @@
 {
-  "llm_model": "gpt-4o-2024-08-06",
+  "llm_model": "gpt-4o",
   "experiment_compiler": {
     "max_revisions": 3
   },


### PR DESCRIPTION
Changed GPT-4o version in config.json due to a change in OpenAI's API that happened today.

<img width="943" alt="Screenshot 2024-10-02 at 10 33 49" src="https://github.com/user-attachments/assets/91c4d99b-c297-4c4a-89f1-db3bbd9544fa">
