### PR TITLE
Add sidebar hamburger menu & enlarge artefact page on small screens

### DIFF
--- a/aria_agents/static/css/App.css
+++ b/aria_agents/static/css/App.css
@@ -1,6 +1,18 @@
 :root {
+    --width-sidebar: 0;
+    --width-artefacts-panel: 100%;
+}
+
+.sidebar.open {
     --width-sidebar: 12em;
-    --width-artefacts-panel: 30%;
+    display: block;
+}
+
+@media (min-width: 768px) {
+    :root{
+        --width-sidebar: 12em;
+        --width-artefacts-panel: 30%;
+    }
 }
 
 @keyframes fadeIn {

--- a/aria_agents/static/js/App.js
+++ b/aria_agents/static/js/App.js
@@ -19,6 +19,7 @@ function App() {
         background: ""
     });
     const [isArtefactsPanelOpen, setIsArtefactsPanelOpen] = useState(false);
+    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
     const [artefacts, setArtefacts] = useState([]);
     const [currentArtefactIndex, setCurrentArtefactIndex] = useState(0);
     const [isLoading, setIsLoading] = useState(false);
@@ -271,8 +272,14 @@ function App() {
 
     return (
         <div className="min-h-screen flex flex-col">
+            <button
+                className={`${isSidebarOpen? 'open' : ''} md:hidden text-4xl p-2 fixed top-0 left-0 mt-4 ml-4`}
+                onClick={() => setIsSidebarOpen(true)}
+            >
+                ☰
+            </button>
             <div className="flex-1 flex">
-                <Sidebar onEditProfile={() => setShowProfileDialog(true)} />
+                <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} onEditProfile={() => setShowProfileDialog(true)} />
                 <div className={`main-panel ${isArtefactsPanelOpen ? 'main-panel-artefacts' : 'main-panel-full'}`}
                     onDrop={handleDrop}
                     onDragOver={handleDragOver}

--- a/aria_agents/static/js/components/ArtefactsPanel.js
+++ b/aria_agents/static/js/components/ArtefactsPanel.js
@@ -5,7 +5,7 @@ function ArtefactsPanel({ onClose, artefacts, currentArtefactIndex, onPrev, onNe
         <div className="artefacts-panel">
             <div className="flex justify-between items-center mb-4">
                 <h2 className="text-xl font-bold">Artefacts</h2>
-                <button onClick={onClose} className="text-gray-600 hover:text-gray-900">X</button>
+                <button onClick={onClose} className="text-2xl text-gray-600 hover:text-gray-900">X</button>
             </div>
             <div className="flex-1 overflow-y-auto mb-4">
                 {artefact && (

--- a/aria_agents/static/js/components/Sidebar.js
+++ b/aria_agents/static/js/components/Sidebar.js
@@ -1,6 +1,7 @@
-function Sidebar({ onEditProfile }) {
+function Sidebar({ isOpen, onClose, onEditProfile }) {
     return (
-        <div className="sidebar">
+        <div className={`hidden md:block sidebar z-50 ${isOpen? 'open' : ''}`}>
+            <button onClick={onClose} className="text-2xl  mt-2 ml-2 p-2 md:hidden text-gray-600 hover:text-gray-900">X</button>
             <div className="text-xl font-bold mb-4">Aria Agents</div>
             <div className="mb-4">
                 <button className="w-full text-left py-2 px-4 rounded hover:bg-gray-200">🏠 Home</button>


### PR DESCRIPTION
Added a hamburger menu in the top left corner that appears in place of the sidebar on smaller devices by default, giving space to other elements on mobile. It can be used to open the full sidebar.