### PR TITLE
Add auto scrolling

### DIFF
--- a/aria_agents/static/js/App.js
+++ b/aria_agents/static/js/App.js
@@ -44,7 +44,7 @@ function App() {
 	const [isSending, setIsSending] = useState(false);
 	const [isChatComplete, setIsChatComplete] = useState(false);
 	const chatContainerRef = useRef(null);
-	const [isAtBottom, setIsAtBottom] = useState(true);
+	const [isNearBottom, setIsNearBottom] = useState(true);
 
 	useEffect(() => {
 		// Automatically generate a session ID
@@ -61,24 +61,22 @@ function App() {
 		if (chatContainerRef.current) {
 			const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
 			const buffer = 100; // Pixels from bottom to consider "at bottom"
-			setIsAtBottom(scrollHeight - scrollTop - clientHeight <= buffer);
+			setIsNearBottom(scrollHeight - scrollTop - clientHeight <= buffer);
+		}
+	};
+
+	const scrollToBottom = () => {
+		if (isNearBottom) {
+			requestAnimationFrame(() => {
+				window.scrollTo({
+					top: document.documentElement.scrollHeight,
+					behavior: 'smooth'
+				});
+			});
 		}
 	};
 
 	useEffect(() => {
-		const scrollToBottom = () => {
-			if (isAtBottom) {
-				requestAnimationFrame(() => {
-					window.scrollTo({
-						top: document.documentElement.scrollHeight,
-						behavior: 'smooth'
-					});
-				});
-			}
-		};
-
-		scrollToBottom();
-
 		// Observe chat container for content changes
 		const observer = new MutationObserver(scrollToBottom);
 		
@@ -91,7 +89,7 @@ function App() {
 		}
 
 		return () => observer.disconnect();
-	}, [chatHistory, isAtBottom]);
+	}, [chatHistory, isNearBottom]);
 
 	const getServices = async (
 		token,
@@ -467,7 +465,9 @@ function App() {
 						{chatHistory.size === 0 ? (
 							<SuggestedStudies setQuestion={setQuestion} />
 						) : (
-							<ChatHistory ref={chatContainerRef} chatHistory={chatHistory} isSending={isSending} />
+							<div ref={chatContainerRef}>
+								<ChatHistory chatHistory={chatHistory} isSending={isSending} />
+							</div>
 						)}
 						{isChatComplete && chatHistory.size > 0 && (
 							<ChatInput


### PR DESCRIPTION
When screen is near bottom of page, page is automatically scrolled to bottom if chathistory expands. Avoids user having to manually scroll to bottom each time there is a new message or a message is expanded.

Resolves #31 